### PR TITLE
feat: add package output to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,8 @@
       darwinPackages = if system == "aarch64-darwin" then [
         pkgs.darwin.apple_sdk.frameworks.ApplicationServices
       ] else [];
+      # Packaged version
+      packageDerivation = pkgs.callPackage ./nix/packages/rtgp-fluid-simulation.nix {};
     in {
       devShells.default = pkgs.mkShell {
         packages = with pkgs; [ 
@@ -19,5 +21,8 @@
           glm 
         ] ++ darwinPackages;
       };
+
+      packages.rtgp-fluid-simulation = packageDerivation;
+      packages.default = packageDerivation;
     });
 }

--- a/nix/packages/rtgp-fluid-simulation.nix
+++ b/nix/packages/rtgp-fluid-simulation.nix
@@ -1,0 +1,31 @@
+{
+  clang13Stdenv,
+  cmake,
+  glew,
+  glfw3,
+  glm,
+  darwin,
+  lib,
+}:
+clang13Stdenv.mkDerivation {
+  name = "rtgp-fluid-simulation";
+  version = "0.0.1";
+
+  src = lib.cleanSource ../..;
+
+  buildInputs =
+    [
+      cmake
+      glew
+      glfw3
+      glm
+    ]
+    ++ (lib.optional (clang13Stdenv.isDarwin)
+      darwin.apple_sdk.frameworks.ApplicationServices);
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp rtgp_fluid_simulation $out/bin/
+    cp -r ../shaders $out/shaders
+  '';
+}


### PR DESCRIPTION
Adds a package output, building the application using cmake. I can't test this atm, as the build proces is broken on x86_64-linux, due to some darwin dependencies, `nix build` aswell as the build process described in the README fail me.

```log
@nix { "action": "setPhase", "phase": "unpackPhase" }
unpacking sources
unpacking source archive /nix/store/cgwiyhv4i970y7xxszng546ykdarc064-source
source root is source
@nix { "action": "setPhase", "phase": "patchPhase" }
patching sources
@nix { "action": "setPhase", "phase": "updateAutotoolsGnuConfigScriptsPhase" }
updateAutotoolsGnuConfigScriptsPhase
@nix { "action": "setPhase", "phase": "configurePhase" }
configuring
fixing cmake files...
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REG>
-- The C compiler identification is Clang 13.0.1
-- The CXX compiler identification is Clang 13.0.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/s2y04a4vaclkh9bpqkbkgzvn1x9ybxgm-clang-wrapper-13.0.1/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/s2y04a4vaclkh9bpqkbkgzvn1x9ybxgm-clang-wrapper-13.0.1/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenGL: /nix/store/hfdqivgjr86fimxs44khhr7ai2kqk893-libGL-1.6.0/lib/libOpenGL.so   
-- Found GLEW: /nix/store/8g4vddvp1iyipar8xwxlwnz46q9g6d9r-glew-2.2.0-dev/include (found suitable version "2.2.0", minimum re>
CMake Error at CMakeLists.txt:42 (message):
  ApplicationServices not found


-- Configuring incomplete, errors occurred!
```